### PR TITLE
Support :ref:, :numref: and conf.py customizations

### DIFF
--- a/sphinxcontrib/thm.py
+++ b/sphinxcontrib/thm.py
@@ -67,12 +67,9 @@ See README.rst file for details
 
 """
 
-import tempfile
-import shutil
-import os
-from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
 from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+from sphinx.transforms import SphinxTransform
 
 __all__ = [ 'newtheorem', 'EnvironmentDirective', 'AlignDirective', 'TextColorDirective', 'TheoremDirectiveFactory']
 
@@ -269,247 +266,219 @@ def visit_textcolor_latex(self, node):
 def depart_textcolor_latex(self, node):
     self.body.append('}')
 
-# TheoremDirectiveFactory:
-def TheoremDirectiveFactory(thmname, thmcaption, thmnode, counter=None):
+def TheoremDirectiveFactory(thmnode, envname, displayname, counter=None):
     """
     Function which returns a theorem class.
 
     Takes four arguments:
-    thmname         - name of the directive
-    thmcaption      - caption name to use
-    thmnode         - node to write to
-    counter         - counter name, if None do not count
+    thmnode         - node to insert in document tree
+    envname         - name to use in source: rst directive, html classes and latex environment
+    displayname     - name to display in output
+    counter         - counter name (if enumerated)
 
-    thmname='theorem', thmcaption='Theorem' will produce a directive::
+    Given (envname,displayname,counter) = ('theorem','Satz',None) 
+    will produce a directive to be used as::
 
-        .. theorem:: theorem_title
+        .. theorem:: TITLE
 
-            content
+            CONTENT
 
-    Note that caption is only used in html.  
-    
-    The directive will produce:
+    to produce in LaTeX::
 
-    in LaTeX::
-
-        \begin{theorem}[{theorem_title}] %  theorem_title will be put inside {}.
-            content
+        \begin{theorem}[TITLE]
+            CONTENT
         \end{theorem}
 
-    in HTML::
+    and in HTML::
 
-        <div class='environment theorem'>
-            <div class='environment_caption theorem_caption'>Theorem</div> <div class='environment_title theorem_title'>title</div>
-            <div class='environment_body theorem_body'>
-                content
+        <div class='thm theorem'>
+            <div class='thm_caption theorem_caption'>Satz <span class='thm_title theorem_title'>TITLE</span></div>
+            <div class='thm_body theorem_body'>
+                CONTENT
             </div>
         </div>
+
+    Note that the latex environment is independent of the displayname 
+    (name in output is controlled by LaTeX preamble), but that :numref: 
+    references to it nevertheless still depends on displayname.
     """
     class TheoremDirective(Directive):
 
-        def __init__(self, *args, **kwargs):
-            self.counter = Counter(counter)
-            super(self.__class__, self).__init__(*args, **kwargs)
-
+        # Accept one optional argument (whitespaces allowed) and content
         required_arguments = 0
         optional_arguments = 1
-
         final_argument_whitespace = True
-        # directive arguments are white space separated.
-
-        option_spec = {
-                    'class': directives.class_option,
-                    'name': directives.unchanged,
-                    }
-
         has_content = True
 
         def run(self):
-
+            self.options['envname'] = envname
+            self.options['displayname'] = displayname
             if counter:
-                self.counter.stepcounter()
-                self.options['counter'] = self.counter.value
-            else:
-                self.options['counter'] = ''
-
-            self.options['thmname'] = thmname
-            self.options['thmcaption'] = thmcaption
+                self.options['counter'] = counter
             if self.arguments:
-                self.options['thmtitle'] = self.arguments[0]
+                self.options['title'] = self.arguments[0]
 
             self.assert_has_content()
             node = thmnode(rawsource='\n'.join(self.content), **self.options)
             self.state.nested_parse(self.content, self.content_offset, node)
-            self.add_name(node)
             return [node]
 
     return TheoremDirective
 
 def visit_thm_latex(self, node):
-    if 'thmtitle' in node:
-        self.body.append('\n\\begin{%(thmname)s}[{%(thmtitle)s}]' % node)
+    if 'title' in node:
+        self.body.append('\n\\begin{%(envname)s}[{%(title)s}]' % node)
     else:
-        self.body.append('\n\\begin{%(thmname)s}' % node)
+        self.body.append('\n\\begin{%(envname)s}' % node)
+
+    # Node-registered and pending labels
+    ids = set(node['ids'])
+    if 'counter' in node:
+        ids |= {id for id in self.pop_hyperlink_ids( node['counter'] )}
+    if ids:
+        labels = ''.join(self.hypertarget(id, anchor=False) for id in sorted(ids))
+        self.body.append('\n' + labels)
 
 def depart_thm_latex(self, node):
-    self.body.append('\\end{%(thmname)s}\n' % node)
+    self.body.append('\\end{%(envname)s}\n' % node)
 
 def visit_thm_html(self, node):
-    """
-    This visit method produces the following html:
+    self.body.append(self.starttag(node, 'div', CLASS='thm %(envname)s' % node))
 
-    The 'theorem' below will be substituted with node['envname'] and title with
-    node['title'] (environment node's option).  Note that it differs slightly
-    from how LaTeX works.
-
-    For how it it constructed see the ``__doc__`` of TheoremDirectiveFactory.
-
-    You cannot use math in the title.
-    """
-    if 'label' in node:
-        ids = [ node['label'] ]
+    # Caption
+    self.body.append('<div class="thm_caption %(envname)s_caption">')
+    if self.builder.env.get_domain('std').is_enumerable_node(node):
+        self.add_fignumber(node)
     else:
-        ids = []
-
-    self.body.append(self.starttag(node, 'div', CLASS='thm %(thmname)s' % node, IDS = ids))
-    self.body.append('<div class="thm_caption %(thmname)s_caption">%(thmcaption)s<span class="thm_counter %(thmname)s_counter">%(counter)s</span>' % node)
-    if 'thmtitle' in node:
-        self.body.append('<span class="thm_title %(thmname)s_title"> %(thmtitle)s </span>' % node)
+        self.body.append('%(displayname)s' % node)
+    if 'title' in node:
+        self.body.append('<span class="thm_title %(envname)s_title"> %(title)s </span>' % node)
     self.body.append('</div>\n')
-    self.body.append('<div class="thm_body %(thmname)s_body">' % node)
-    self.set_first_last(node)
+
+    # Body
+    self.body.append('<div class="thm_body %(envname)s_body">' % node)
 
 def depart_thm_html(self, node):
     self.body.append('</div>')
     self.body.append('</div>\n')
 
-class Counter(object):
-    """
-    Base class for counters.  There is only one instance for a given name.
-
-        >>> c=Counter('counter')
-        >>> d=Counter('counter')
-        >>> c id d
-        True
-
-    This is done using ``__new__`` method.
-    """
-
-    registered_counters = {}
-
-    def __new__(cls, name, value=0, within=None):
-        if name in cls.registered_counters:
-            instance = cls.registered_counters[name]
-            instance._init = False
-            return instance
-        else:
-            instance = super(Counter, cls).__new__(cls)
-            instance.name = name
-            instance.value = value
-            instance._init = True
-            return instance
-
-    def __init__(self, name, value=0, within=None):
-        if not self._init:
-            # __init__ once
-            return
-        self.name = name
-        self.value = value
-
-        self.register()
-
-    def register(self):
-        Counter.registered_counters[self.name] = self
-
-    def stepcounter(self):
-        self.value += 1
-
-    def addtocounter(self, value=1):
-        self.value += value
-
-    def setcounter(self, value):
-        self.value = value
-
-    def __str__(self):
-        return str(self.value) if self.name else ""
-
-    def __unicode__(self):
-        return str(self.value) if self.name else ""
-
 class TheoremNode(nodes.Element):
     pass
 
-# newtheorem:
-def newtheorem(app, thmname, thmcaption, counter=None):
+def get_thmnode_title(thmnode):
+    return thmnode.get('title',None)
+
+def newtheorem(app, envname, displayname, counter=None):
     """
     Add new theorem.  It is thought as an analog to latex::
+        \\newtheorem{envname}[counter]{displayname}
 
-        \\newtheorem{theorem_name}{caption}
-
-    counter is an instance of Counter.  If None (the default),
+    If the counter is None (the default),
     the constructed theorem will not be counted.
     """
 
-    nodename = 'thmnode_%s' % thmname
-    thmnode = type(nodename, (TheoremNode,), {})
-    globals()[nodename]=thmnode # important for pickling
-    app.add_node(thmnode,
-                    html = (visit_thm_html, depart_thm_html),
-                    latex = (visit_thm_latex, depart_thm_latex),
-                )
-    TheoremDirective = TheoremDirectiveFactory(thmname, thmcaption, thmnode, counter)
-    app.add_directive(thmname, TheoremDirective)
+    clsname = 'thmnode_%s' % envname
+    thmnode = type(clsname, (TheoremNode,), {})
+    globals()[clsname]=thmnode # important for pickling
+
+    if counter:
+        app.config.numfig_format.setdefault(envname, displayname+' %s')
+        app.add_enumerable_node(thmnode, counter, get_thmnode_title,
+            html = (visit_thm_html, depart_thm_html),
+            latex = (visit_thm_latex, depart_thm_latex))
+    else:
+        app.add_node(thmnode, 
+                        html = (visit_thm_html, depart_thm_html),
+                        latex = (visit_thm_latex, depart_thm_latex))
+
+    TheoremDirective = TheoremDirectiveFactory(thmnode, envname, displayname, counter)
+    app.add_directive(envname, TheoremDirective)
 
 
-# setup:
-def setup(app):
+class TheoremAutoNumbering(SphinxTransform):
+    """
+    Register nonempty IDs of enumerable nodes 
+    (for some reason sphinx/transforms/__init__.py skips nodes without title
+    making LaTeX and HTML theorem numbering different)
+    """
+    default_priority = 210
 
-    app.add_directive('environment', EnvironmentDirective)
-    app.add_node(environment,
-                html = (visit_environment_html, depart_environment_html),
-                latex = (visit_environment_latex, depart_environment_latex),
-            )
+    def apply(self):
+        # type: () -> None
+        domain = self.env.get_domain('std')  # type: StandardDomain
 
-    app.add_directive('align', AlignDirective)
-    app.add_node(align,
-                html =  (visit_align_html, depart_align_html),
-                latex = (visit_align_latex, depart_align_latex),
-            )
+        for node in self.document.traverse(TheoremNode):
+            if domain.is_enumerable_node(node):
+                self.document.note_implicit_target(node)
 
-    app.add_directive('textcolor', TextColorDirective)
-    app.add_role('textcolor', textcolor_role)
-    app.add_node(textcolor,
+
+def install_extension(app):
+    if app.config['thm_use_environment']:
+        app.add_directive('environment', EnvironmentDirective)
+        app.add_node(environment,
+            html = (visit_environment_html, depart_environment_html),
+            latex = (visit_environment_latex, depart_environment_latex))
+
+    if app.config['thm_use_align']:
+        app.add_directive('align', AlignDirective)
+        app.add_node(align,
+            html = (visit_align_html, depart_align_html),
+            latex = (visit_align_latex, depart_align_latex))
+
+    if app.config['thm_use_textcolor']:
+        app.add_directive('textcolor', TextColorDirective)
+        app.add_role('textcolor', textcolor_role)
+        app.add_node(textcolor,
             html = (visit_textcolor_html, depart_textcolor_html),
-            latex = (visit_textcolor_latex, depart_textcolor_latex)
-            )
+            latex = (visit_textcolor_latex, depart_textcolor_latex))
 
-    # Add theorems from amsthm
-    newtheorem(app,'theorem','Theorem','theorem')
-    newtheorem(app,'lemma','Lemma','lemma')
-    newtheorem(app,'corollary','Corollary','corollary')
-    newtheorem(app,'proposition','Proposition','proposition')
-    newtheorem(app,'conjecture','Conjecture','conjecture')
-    newtheorem(app,'criterion','Criterion','criterion')
-    newtheorem(app,'assertion','Assertion','assertion')
-    newtheorem(app,'definition','Definition','definition')
-    newtheorem(app,'condition','Condition','condition')
-    newtheorem(app,'problem','Problem','problem')
-    newtheorem(app,'example','Example','example')
-    newtheorem(app,'exercise','Exercise','exercise')
-    newtheorem(app,'algorithm','Algorithm','algorithm')
-    newtheorem(app,'question','Question','question')
-    newtheorem(app,'axiom','Axiom','axiom')
-    newtheorem(app,'property','Property','property')
-    newtheorem(app,'assumption','Assumption','assumption')
-    newtheorem(app,'hypothesis','Hypothesis','hypothesis')
-    newtheorem(app,'remark','Remark','remark')
-    newtheorem(app,'notation','Notation','notation')
-    newtheorem(app,'claim','Claim','claim')
-    newtheorem(app,'summary','Summary','summary')
-    newtheorem(app,'acknowledgment','Acknowledgment','acknowledgment')
-    newtheorem(app,'case','Case','case')
-    newtheorem(app,'conclusion','Conclusion','conclusion')
-    newtheorem(app,'proof','Proof','proof')
+    for t in app.config['thm_theorems']:
+        newtheorem(app, *t)
+
+
+def setup(app):
+    app.add_config_value('thm_use_environment', False, 'env')
+    app.add_config_value('thm_use_textcolor', False, 'env')
+    app.add_config_value('thm_use_align', False, 'env')
+    app.add_config_value('thm_theorems', [], 'env')
+    app.connect('builder-inited', install_extension)
+    app.add_transform(TheoremAutoNumbering)
+
+    ############################
+    # conf.py example setting
+    ############################
+    # thm_use_environment = True
+    # thm_use_textcolor = True
+    # thm_use_align = True
+    # thm_theorems = [
+    #     ('theorem','Theorem','theorem'),
+    #     ('lemma','Lemma','lemma'),
+    #     ('corollary','Corollary','corollary'),
+    #     ('proposition','Proposition','proposition'),
+    #     ('conjecture','Conjecture','conjecture'),
+    #     ('criterion','Criterion','criterion'),
+    #     ('assertion','Assertion','assertion'),
+    #     ('definition','Definition','definition'),
+    #     ('condition','Condition','condition'),
+    #     ('problem','Problem','problem'),
+    #     ('example','Example','example'),
+    #     ('exercise','Exercise','exercise'),
+    #     ('algorithm','Algorithm','algorithm'),
+    #     ('question','Question','question'),
+    #     ('axiom','Axiom','axiom'),
+    #     ('property','Property','property'),
+    #     ('assumption','Assumption','assumption'),
+    #     ('hypothesis','Hypothesis','hypothesis'),
+    #     ('remark','Remark','remark'),
+    #     ('notation','Notation','notation'),
+    #     ('claim','Claim','claim'),
+    #     ('summary','Summary','summary'),
+    #     ('acknowledgment','Acknowledgment','acknowledgment'),
+    #     ('case','Case','case'),
+    #     ('conclusion','Conclusion','conclusion'),
+    #     ('proof','Proof')
+    # ]
+    
 
 
 # test if there is no global name which starts with 'thmnode_', 


### PR DESCRIPTION
I took up the challenge and succeeded enabling references via :numref: and :ref: to theorems. I have not touched the other directives as I do not use them, and for the same reason added 4 configuration parameters to enable/disable features via conf.py.